### PR TITLE
highchartにtopコンポーネントのチェックボックス押下時、人口データを流しグラフ表示まで完了

### DIFF
--- a/src/components/organisms/ChartArea.tsx
+++ b/src/components/organisms/ChartArea.tsx
@@ -1,0 +1,31 @@
+import * as Highcharts from "highcharts";
+import HighchartsReact from "highcharts-react-official";
+import Title from "../atoms/Title";
+
+export default function ChartArea() {
+  const options = {
+    title: {
+      text: "都道府県 人口データ",
+    },
+    series: [
+      {
+        data: [10000, 15000, 13000],
+      },
+    ],
+    plotOptions: {
+      series: {
+        label: {
+          connectorAllowed: false,
+        },
+        pointRange: 10,
+        pointStart: 1970,
+      },
+    },
+  };
+  return (
+    <section>
+      <Title title="グラフ" />
+      <HighchartsReact highcharts={Highcharts} options={options} />
+    </section>
+  );
+}

--- a/src/components/organisms/ChartArea.tsx
+++ b/src/components/organisms/ChartArea.tsx
@@ -9,14 +9,45 @@ export default function ChartArea({ prefPopChartDatas }: ChartDataProps) {
       text: "都道府県 人口データ",
     },
     series: prefPopChartDatas,
+    xAxis: {
+      title: {
+        text: "年度",
+      },
+      accessibility: {
+        rangeDescription: "Range: 1960 to 2045",
+      },
+      categories: [
+        "1960",
+        "1965",
+        "1970",
+        "1975",
+        "1980",
+        "1985",
+        "1990",
+        "1995",
+        "2000",
+        "2005",
+        "2010",
+        "2015",
+        "2020",
+        "2025",
+        "2030",
+        "2035",
+        "2040",
+        "2045",
+      ],
+    },
     plotOptions: {
       series: {
         label: {
           connectorAllowed: false,
         },
-        pointRange: 10,
-        pointStart: 1970,
       },
+    },
+    legend: {
+      layout: "vertical",
+      align: "right",
+      verticalAlign: "middle",
     },
   };
   return (

--- a/src/components/organisms/ChartArea.tsx
+++ b/src/components/organisms/ChartArea.tsx
@@ -1,17 +1,14 @@
 import * as Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 import Title from "../atoms/Title";
+import { ChartDataProps } from "../../types/Props";
 
-export default function ChartArea() {
+export default function ChartArea({ prefPopChartDatas }: ChartDataProps) {
   const options = {
     title: {
       text: "都道府県 人口データ",
     },
-    series: [
-      {
-        data: [10000, 15000, 13000],
-      },
-    ],
+    series: prefPopChartDatas,
     plotOptions: {
       series: {
         label: {

--- a/src/components/templates/TopTemplate.tsx
+++ b/src/components/templates/TopTemplate.tsx
@@ -2,11 +2,14 @@ import { TopTemplateProps } from "../../types/Props";
 import ChartArea from "../organisms/ChartArea";
 import PrefListArea from "../organisms/PrefListArea";
 
-export default function TopTemplate({ prefData }: TopTemplateProps) {
+export default function TopTemplate({
+  prefData,
+  prefPopChartDatas,
+}: TopTemplateProps) {
   return (
     <main>
       <PrefListArea prefData={prefData} />
-      <ChartArea />
+      <ChartArea prefPopChartDatas={prefPopChartDatas} />
     </main>
   );
 }

--- a/src/components/templates/TopTemplate.tsx
+++ b/src/components/templates/TopTemplate.tsx
@@ -1,10 +1,12 @@
 import { TopTemplateProps } from "../../types/Props";
+import ChartArea from "../organisms/ChartArea";
 import PrefListArea from "../organisms/PrefListArea";
 
 export default function TopTemplate({ prefData }: TopTemplateProps) {
   return (
     <main>
       <PrefListArea prefData={prefData} />
+      <ChartArea />
     </main>
   );
 }

--- a/src/functions/parseApiDataToChartData.ts
+++ b/src/functions/parseApiDataToChartData.ts
@@ -1,0 +1,12 @@
+import { YearAndPopObj } from "../types/Variables";
+
+export const parseApiDataToChartData = (
+  apiData: YearAndPopObj[],
+  prefName: string
+) => {
+  return {
+    name: prefName,
+    type: "line",
+    data: apiData.map((item: YearAndPopObj) => item.value),
+  };
+};

--- a/src/pages/Top.tsx
+++ b/src/pages/Top.tsx
@@ -2,23 +2,43 @@ import { useQuery } from "@tanstack/react-query";
 import { getPopByPrefecture } from "../functions/getPopByPrefecture";
 import TopTemplate from "../components/templates/TopTemplate";
 import { getPrefectures } from "../functions/getPrefectures";
+import { parseApiDataToChartData } from "../functions/parseApiDataToChartData";
+import { useState } from "react";
+import { ChartData } from "../types/Variables";
 
 export default function Top() {
-  // const prefCode = 10;
-  // const query = useQuery({
-  //   queryKey: [`${prefCode}`],
-  //   queryFn: () => getPopByPrefecture(prefCode),
-  // });
-  // console.log(query.data);
-
   const prefData = useQuery({
     queryKey: [`prefectures`],
     queryFn: () => getPrefectures(),
   });
-  console.log("prefData", prefData);
+
+  const [prefPopChartDatas, setPrefChartData] = useState<ChartData[]>([]);
+
+  //highchartにデータを流す処理から実装するため、一時的に1を指定
+  const checkedPrefCode = "1";
+
+  const prefPopData = useQuery({
+    queryKey: [`${Number(checkedPrefCode)}`],
+    queryFn: () => getPopByPrefecture(Number(checkedPrefCode)),
+    enabled: checkedPrefCode !== null,
+  });
+
+  if (prefPopData.isPending) return <>loading</>;
+
+  const handleChangeMainCheckBox = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const chartData = parseApiDataToChartData(
+      prefPopData.data.result.data[0].data,
+      e.target.id
+    );
+    setPrefChartData([...prefPopChartDatas, chartData]);
+    console.log("prefPopChartDatas", prefPopChartDatas);
+  };
+
   return (
     <>
-      <TopTemplate prefData={prefData} />
+      <TopTemplate prefData={prefData} prefPopChartDatas={prefPopChartDatas} />
+      {/* ダミーチェックボックス（チェックボックス押下時の動作確認用、MainCheckBoxの代わり） */}
+      <input type="checkbox" id="東京" onChange={handleChangeMainCheckBox} />
     </>
   );
 }

--- a/src/types/Props.ts
+++ b/src/types/Props.ts
@@ -1,4 +1,5 @@
 import { UseQueryResult } from "@tanstack/react-query";
+import { ChartData } from "./Variables";
 
 export interface TitleProps {
   title: string;
@@ -20,8 +21,13 @@ export interface PrefCheckBoxProps {
 
 export interface TopTemplateProps {
   prefData: UseQueryResult<any, Error>;
+  prefPopChartDatas: ChartData[];
 }
 
 export interface PrefListAreaProps {
   prefData: UseQueryResult<any, Error>;
+}
+
+export interface ChartDataProps {
+  prefPopChartDatas: ChartData[];
 }

--- a/src/types/Variables.ts
+++ b/src/types/Variables.ts
@@ -2,3 +2,14 @@ export interface PrefData {
   prefCode: number;
   prefName: string;
 }
+
+export interface YearAndPopObj {
+  year: number;
+  value: number;
+}
+
+export interface ChartData {
+  name: string;
+  type: string;
+  data: number[];
+}


### PR DESCRIPTION
**・チェックボックス押下時、データを取得する機能を実装しました**
チェックボックスはMainCheckBoxコンポーネントを使用しますが、現在はTopコンポーネントにダミーで設置したチェックボックスでデータ取得の確認をしています。

また、取得したデータをparseApiDataToChartData関数でhighchartに適したデータ構造に変換し、グラフのコンポーネントまで渡しています

**・対応していない箇所**
チェックボックス押下時、既に押下ずみ（checked）の場合の処理は記述していません。
また、チェックボックスのハンドラーはコンテキストでMainCheckBoxコンポーネントに渡す予定です。

Tanstack queryにパラメータを渡す方法が難航しているため、現在はダミーのパラメーターで実装しています。
（Topコンポーネント18行目）

現状チェックボックスを押下するだけで全コンポーネントが再レンダリングされるため、パフォーマンス改善も今後行います

**・画面キャプチャ**

https://github.com/kaitokosuge/PopChart/assets/134667077/e49a0b70-b39f-446f-bfc0-ce20421aee5a

