### PR TITLE
useQueryの呼び出しをMainCheckBoxに変更し、コンテキストでハンドラーを管理

### DIFF
--- a/src/components/atoms/MainCheckBox.tsx
+++ b/src/components/atoms/MainCheckBox.tsx
@@ -1,6 +1,13 @@
 import { MainCheckBoxProps } from "../../types/Props";
 import atomes from "../../assets/css/atoms.module.css";
+import { useQuery } from "@tanstack/react-query";
+import { getPopByPrefecture } from "../../functions/getPopByPrefecture";
 
 export default function MainCheckBox({ id }: MainCheckBoxProps) {
+  const prefPopData = useQuery({
+    queryKey: [`${Number(id)}`],
+    queryFn: () => getPopByPrefecture(Number(id)),
+  });
+  console.log("prefPopData", prefPopData);
   return <input type="checkbox" id={id} className={atomes.main_checkbox} />;
 }

--- a/src/components/atoms/MainCheckBox.tsx
+++ b/src/components/atoms/MainCheckBox.tsx
@@ -2,12 +2,21 @@ import { MainCheckBoxProps } from "../../types/Props";
 import atomes from "../../assets/css/atoms.module.css";
 import { useQuery } from "@tanstack/react-query";
 import { getPopByPrefecture } from "../../functions/getPopByPrefecture";
+import { useChangeCheckBox } from "../../hooks/useChangeCheckBox";
 
 export default function MainCheckBox({ id }: MainCheckBoxProps) {
+  const { handleChangeMainCheckBox } = useChangeCheckBox();
   const prefPopData = useQuery({
     queryKey: [`${Number(id)}`],
     queryFn: () => getPopByPrefecture(Number(id)),
   });
   console.log("prefPopData", prefPopData);
-  return <input type="checkbox" id={id} className={atomes.main_checkbox} />;
+  return (
+    <input
+      type="checkbox"
+      id={id}
+      className={atomes.main_checkbox}
+      onChange={(e) => handleChangeMainCheckBox(e, prefPopData)}
+    />
+  );
 }

--- a/src/components/organisms/PrefListArea.tsx
+++ b/src/components/organisms/PrefListArea.tsx
@@ -27,7 +27,7 @@ export default function PrefListArea({ prefData }: PrefListAreaProps) {
       <div className={organisms.pref_listarea}>
         {prefData.data.result.map((pref: PrefData) => (
           <PrefCheckBox
-            id={pref.prefName}
+            id={String(pref.prefCode)}
             prefName={pref.prefName}
             key={pref.prefName}
           />

--- a/src/hooks/useChangeCheckBox.ts
+++ b/src/hooks/useChangeCheckBox.ts
@@ -1,0 +1,21 @@
+import { UseQueryResult } from "@tanstack/react-query";
+import { createContext, useContext } from "react";
+
+interface ChartContextType {
+  handleChangeMainCheckBox: (
+    e: React.ChangeEvent<HTMLInputElement>,
+    prefPopData: UseQueryResult<any, Error>
+  ) => JSX.Element | undefined;
+}
+
+export const ChangeCheckBoxContext = createContext<
+  ChartContextType | undefined
+>(undefined);
+
+export const useChangeCheckBox = () => {
+  const context = useContext(ChangeCheckBoxContext);
+  if (!context) {
+    throw new Error("useChart must be used within a ChartProvider");
+  }
+  return context;
+};

--- a/src/pages/Top.tsx
+++ b/src/pages/Top.tsx
@@ -1,5 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
-import { getPopByPrefecture } from "../functions/getPopByPrefecture";
+import { UseQueryResult, useQuery } from "@tanstack/react-query";
 import TopTemplate from "../components/templates/TopTemplate";
 import { getPrefectures } from "../functions/getPrefectures";
 import { parseApiDataToChartData } from "../functions/parseApiDataToChartData";
@@ -14,18 +13,14 @@ export default function Top() {
 
   const [prefPopChartDatas, setPrefChartData] = useState<ChartData[]>([]);
 
-  //highchartにデータを流す処理から実装するため、一時的に1を指定
-  const checkedPrefCode = "1";
+  const handleChangeMainCheckBox = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    prefPopData: UseQueryResult<any, Error>
+  ) => {
+    if (prefPopData.isPending) {
+      return <>loading</>;
+    }
 
-  const prefPopData = useQuery({
-    queryKey: [`${Number(checkedPrefCode)}`],
-    queryFn: () => getPopByPrefecture(Number(checkedPrefCode)),
-    enabled: checkedPrefCode !== null,
-  });
-
-  if (prefPopData.isPending) return <>loading</>;
-
-  const handleChangeMainCheckBox = (e: React.ChangeEvent<HTMLInputElement>) => {
     const chartData = parseApiDataToChartData(
       prefPopData.data.result.data[0].data,
       e.target.id
@@ -38,7 +33,30 @@ export default function Top() {
     <>
       <TopTemplate prefData={prefData} prefPopChartDatas={prefPopChartDatas} />
       {/* ダミーチェックボックス（チェックボックス押下時の動作確認用、MainCheckBoxの代わり） */}
-      <input type="checkbox" id="東京" onChange={handleChangeMainCheckBox} />
+      {/* <input
+        type="checkbox"
+        id="東京"
+        value="2"
+        onChange={handleChangeMainCheckBox}
+      /> */}
     </>
   );
 }
+// export const TestCheckbox = () => {
+//   const checkedPrefCode: string = "1";
+//   const prefPopData = useQuery({
+//     queryKey: [`${Number(checkedPrefCode)}`],
+//     queryFn: () => getPopByPrefecture(Number(checkedPrefCode)),
+//     enabled: checkedPrefCode !== null,
+//   });
+//   return (
+//     <>
+//       <input
+//         type="checkbox"
+//         id="東京"
+//         value="2"
+//         onChange={handleChangeMainCheckBox}
+//       />
+//     </>
+//   );
+// };

--- a/src/pages/Top.tsx
+++ b/src/pages/Top.tsx
@@ -42,21 +42,3 @@ export default function Top() {
     </>
   );
 }
-// export const TestCheckbox = () => {
-//   const checkedPrefCode: string = "1";
-//   const prefPopData = useQuery({
-//     queryKey: [`${Number(checkedPrefCode)}`],
-//     queryFn: () => getPopByPrefecture(Number(checkedPrefCode)),
-//     enabled: checkedPrefCode !== null,
-//   });
-//   return (
-//     <>
-//       <input
-//         type="checkbox"
-//         id="東京"
-//         value="2"
-//         onChange={handleChangeMainCheckBox}
-//       />
-//     </>
-//   );
-// };

--- a/src/pages/Top.tsx
+++ b/src/pages/Top.tsx
@@ -4,6 +4,7 @@ import { getPrefectures } from "../functions/getPrefectures";
 import { parseApiDataToChartData } from "../functions/parseApiDataToChartData";
 import { useState } from "react";
 import { ChartData } from "../types/Variables";
+import { ChangeCheckBoxContext } from "../hooks/useChangeCheckBox";
 
 export default function Top() {
   const prefData = useQuery({
@@ -20,25 +21,25 @@ export default function Top() {
     if (prefPopData.isPending) {
       return <>loading</>;
     }
-
     const chartData = parseApiDataToChartData(
       prefPopData.data.result.data[0].data,
       e.target.id
     );
     setPrefChartData([...prefPopChartDatas, chartData]);
-    console.log("prefPopChartDatas", prefPopChartDatas);
   };
 
   return (
     <>
-      <TopTemplate prefData={prefData} prefPopChartDatas={prefPopChartDatas} />
-      {/* ダミーチェックボックス（チェックボックス押下時の動作確認用、MainCheckBoxの代わり） */}
-      {/* <input
-        type="checkbox"
-        id="東京"
-        value="2"
-        onChange={handleChangeMainCheckBox}
-      /> */}
+      <ChangeCheckBoxContext.Provider
+        value={{
+          handleChangeMainCheckBox,
+        }}
+      >
+        <TopTemplate
+          prefData={prefData}
+          prefPopChartDatas={prefPopChartDatas}
+        />
+      </ChangeCheckBoxContext.Provider>
     </>
   );
 }


### PR DESCRIPTION
**・useQueryの呼び出しをMainCheckBoxで行うように変更しました**

MainCheckBoxで呼び出すことでパラメーター（都道府県コード）を渡せるようにしました。

**・チェックボックスのハンドラーをコンテキストで管理するようにしました**

**・画面キャプチャ**

https://github.com/kaitokosuge/PopChart/assets/134667077/c86282ed-1707-48cd-a83b-1bec3afd230f

