### PR TITLE
人口情報ごとにグラフを切り替える機能完了

### DIFF
--- a/src/components/atoms/MainCheckBox.tsx
+++ b/src/components/atoms/MainCheckBox.tsx
@@ -5,7 +5,7 @@ import { getPopByPrefecture } from "../../functions/getPopByPrefecture";
 import { useChangeCheckBox } from "../../hooks/useChangeCheckBox";
 import { memo } from "react";
 
-function MainCheckBox({ id }: MainCheckBoxProps) {
+function MainCheckBox({ id, prefName }: MainCheckBoxProps) {
   const { handleChangeMainCheckBox } = useChangeCheckBox();
   const prefPopData = useQuery({
     queryKey: [`${Number(id)}`],
@@ -16,7 +16,7 @@ function MainCheckBox({ id }: MainCheckBoxProps) {
   return (
     <input
       type="checkbox"
-      id={id}
+      id={prefName}
       className={atomes.main_checkbox}
       onChange={(e) => handleChangeMainCheckBox(e, prefPopData)}
     />

--- a/src/components/atoms/MainLabel.tsx
+++ b/src/components/atoms/MainLabel.tsx
@@ -2,9 +2,9 @@ import { MainLabelProps } from "../../types/Props";
 import atomes from "../../assets/css/atoms.module.css";
 import { memo } from "react";
 
-function MainLabel({ id, prefName }: MainLabelProps) {
+function MainLabel({ prefName }: MainLabelProps) {
   return (
-    <label htmlFor={id} className={atomes.main_label}>
+    <label htmlFor={prefName} className={atomes.main_label}>
       {prefName}
     </label>
   );

--- a/src/components/molucules/PrefCheckBox.tsx
+++ b/src/components/molucules/PrefCheckBox.tsx
@@ -9,8 +9,8 @@ import { memo } from "react";
 function PrefCheckBox({ id, prefName }: PrefCheckBoxProps) {
   return (
     <div className={molucules.pref_checkbox}>
-      <MainCheckBox id={id} />
-      <MainLabel id={id} prefName={prefName} />
+      <MainCheckBox id={id} prefName={prefName} />
+      <MainLabel prefName={prefName} />
     </div>
   );
 }

--- a/src/components/organisms/ChartArea.tsx
+++ b/src/components/organisms/ChartArea.tsx
@@ -3,6 +3,7 @@ import HighchartsReact from "highcharts-react-official";
 import Title from "../atoms/Title";
 import { ChartDataProps } from "../../types/Props";
 import { useState } from "react";
+import { ChartData } from "../../types/Variables";
 
 export default function ChartArea({ prefPopChartDatas }: ChartDataProps) {
   const [popStatus, setPopStatus] = useState(0);
@@ -10,11 +11,13 @@ export default function ChartArea({ prefPopChartDatas }: ChartDataProps) {
     setPopStatus(popStatusNum);
   };
 
-  const seriesData = prefPopChartDatas.map((item: any) => {
+  const seriesData = prefPopChartDatas.map((item: ChartData) => {
     return {
       name: item.name,
       type: item.type,
-      data: item.data[popStatus].map((item: any) => item.value),
+      data: item.data[popStatus].map(
+        (item: { year: number; value: number }) => item.value
+      ),
     };
   });
 

--- a/src/components/organisms/ChartArea.tsx
+++ b/src/components/organisms/ChartArea.tsx
@@ -2,13 +2,27 @@ import * as Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 import Title from "../atoms/Title";
 import { ChartDataProps } from "../../types/Props";
+import { useState } from "react";
 
 export default function ChartArea({ prefPopChartDatas }: ChartDataProps) {
+  const [popStatus, setPopStatus] = useState(0);
+  const handleClickChangePopDataStatus = (popStatusNum: number) => {
+    setPopStatus(popStatusNum);
+  };
+
+  const seriesData = prefPopChartDatas.map((item: any) => {
+    return {
+      name: item.name,
+      type: item.type,
+      data: item.data[popStatus].map((item: any) => item.value),
+    };
+  });
+
   const options = {
     title: {
       text: "都道府県 人口データ",
     },
-    series: prefPopChartDatas,
+    series: seriesData,
     xAxis: {
       title: {
         text: "年度",
@@ -53,6 +67,12 @@ export default function ChartArea({ prefPopChartDatas }: ChartDataProps) {
   return (
     <section>
       <Title title="グラフ" />
+      <div>
+        <p onClick={() => handleClickChangePopDataStatus(0)}>総人口</p>
+        <p onClick={() => handleClickChangePopDataStatus(1)}>年少人口</p>
+        <p onClick={() => handleClickChangePopDataStatus(2)}>生産年齢人口</p>
+        <p onClick={() => handleClickChangePopDataStatus(3)}>老年人口</p>
+      </div>
       <HighchartsReact highcharts={Highcharts} options={options} />
     </section>
   );

--- a/src/functions/parseApiDataToChartData.ts
+++ b/src/functions/parseApiDataToChartData.ts
@@ -7,6 +7,6 @@ export const parseApiDataToChartData = (
   return {
     name: prefName,
     type: "line",
-    data: apiData.map((item: YearAndPopObj) => item.value),
+    data: apiData.map((item: any) => item.data),
   };
 };

--- a/src/functions/parseApiDataToChartData.ts
+++ b/src/functions/parseApiDataToChartData.ts
@@ -1,12 +1,12 @@
-import { YearAndPopObj } from "../types/Variables";
+import { PopLabelData } from "../types/Variables";
 
 export const parseApiDataToChartData = (
-  apiData: YearAndPopObj[],
+  apiData: PopLabelData[],
   prefName: string
 ) => {
   return {
     name: prefName,
     type: "line",
-    data: apiData.map((item: any) => item.data),
+    data: apiData.map((item: PopLabelData) => item.data),
   };
 };

--- a/src/pages/Top.tsx
+++ b/src/pages/Top.tsx
@@ -21,10 +21,12 @@ export default function Top() {
     if (prefPopData.isPending) {
       return <>loading</>;
     }
+
     const chartData = parseApiDataToChartData(
-      prefPopData.data.result.data[0].data,
+      prefPopData.data.result.data,
       e.target.id
     );
+
     if (prefPopChartDatas.some((item) => item.name === e.target.id)) {
       setPrefChartData(
         prefPopChartDatas.filter((item) => item.name !== e.target.id)

--- a/src/types/Props.ts
+++ b/src/types/Props.ts
@@ -7,10 +7,10 @@ export interface TitleProps {
 
 export interface MainCheckBoxProps {
   id: string;
+  prefName: string;
 }
 
 export interface MainLabelProps {
-  id: string;
   prefName: string;
 }
 

--- a/src/types/Variables.ts
+++ b/src/types/Variables.ts
@@ -11,5 +11,5 @@ export interface PopLabelData {
 export interface ChartData {
   name: string;
   type: string;
-  data: number[];
+  data: number[][];
 }

--- a/src/types/Variables.ts
+++ b/src/types/Variables.ts
@@ -3,9 +3,9 @@ export interface PrefData {
   prefName: string;
 }
 
-export interface YearAndPopObj {
-  year: number;
-  value: number;
+export interface PopLabelData {
+  label: string;
+  data: number[];
 }
 
 export interface ChartData {

--- a/src/types/Variables.ts
+++ b/src/types/Variables.ts
@@ -5,11 +5,11 @@ export interface PrefData {
 
 export interface PopLabelData {
   label: string;
-  data: number[];
+  data: { year: number; value: number }[];
 }
 
 export interface ChartData {
   name: string;
   type: string;
-  data: number[][];
+  data: { year: number; value: number }[][];
 }


### PR DESCRIPTION
**・人口情報ごとにグラフを切り替える機能が完了しました**
ChartAreaコンポーネントに人口情報を指定したデータを送るのではなく、4種類の人口情報データを含んだデータを送るように変更しました。また、ChartAreaコンポーネント内でどの人口情報データを表示させるのかを管理しています。

これによりユーザーが人口情報を変更した際、チェックした要素がリセットされないようになっています。

一方、人口情報を変更した際、チェックした要素がリセットされた方が好ましいユーザーもいることが想定されるため、チェックボックスを全リセットできる機能も検討したいと思います

**・上記に伴い、各プロップスの型注釈を変更しました**
エラーは出ていません

**・人口情報を選択するボタンは次回作業時、buttonタグに変換します（アクセシビリティのため）**

**・画面キャプチャ**

https://github.com/kaitokosuge/PopChart/assets/134667077/5304c8cc-60b9-44be-8f52-95ec8df6b55e

